### PR TITLE
Fixing constructor error in PHP7

### DIFF
--- a/include/cpto-class.php
+++ b/include/cpto-class.php
@@ -4,7 +4,7 @@
         {
             var $current_post_type = null;
             
-            function CPTO() 
+            function __construct() 
                 {
                     add_action( 'admin_init', array(&$this, 'registerFiles'), 11 );
                     add_action( 'admin_init', array(&$this, 'checkPost'), 10 );


### PR DESCRIPTION
PHP7 is throwing a deprecation notice on every page with this plugin:

`Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; CPTO has a deprecated constructor in /wp-content/plugins/post-types-order/include/cpto-class.php on line 3`

This fix just changes the CPTO class to use an actual constructor function.
